### PR TITLE
Update the README to include vertex ai workbench support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,42 @@
-# Generative AI Hackathon
+<h1 align="center"> Generative AI Hackathon</h1>
+<table align="center">
+    <td>
+        <a href="https://colab.research.google.com/github/teamdatatonic/gen-ai-hackathon/blob/main/hackathon.ipynb">
+            <img src="https://cloud.google.com/ml-engine/images/colab-logo-32px.png" alt="Colab logo">
+            <span style="vertical-align: middle;">Run in Colab</span>
+        </a>
+    </td>
+    <td>
+        <a href="https://github.com/teamdatatonic/gen-ai-hackathon/blob/main/hackathon.ipynb">
+            <img src="https://cloud.google.com/ml-engine/images/github-logo-32px.png" alt="GitHub logo">
+            <span style="vertical-align: middle;">View on GitHub</span>
+        </a>
+    </td>
+    <td>
+        <a href="https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/teamdatatonic/gen-ai-hackathon/main/hackathon.ipynb">
+            <img src="https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32" alt="Vertex AI logo"> 
+            <span style="vertical-align: middle;">Open in Vertex AI Workbench</span>
+        </a>
+    </td>
+</table>
+<hr>
 
-<a target="_blank" href="https://colab.research.google.com/github/teamdatatonic/gen-ai-hackathon/blob/main/hackathon.ipynb">
-  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
-</a>
+**➡️ Your task:** Learn about Generative AI by building your own Knowledge Worker using Python and LangChain!
 
-LangChain is a Python framework for developing applications using language models. 
-It abstracts the connection between applications and LLMs, allowing a loose coupling between code and specific foundation models like Google PaLM.
+**❗ Note:** This workshop has been designed to be run in Google CoLab. Support for running the workshop locally or using VertexAI Workbench is provided, but we heavily recommend CoLab for the best experience.
 
-## The challenge
-
-Open [the notebook](hackathon.ipynb) in Jupyter or [Google CoLab](https://colab.research.google.com/github/teamdatatonic/gen-ai-hackathon/blob/main/hackathon.ipynb). 
-The notebook is self-contained (includes python `pip` install commands).
-However, the following pre-requisites are required to get started:
-
-- Google Cloud Project with  Vertex AI API enabled
+The notebook is self-contained (includes python `pip` install commands), however, the following pre-requisites are required to get started:
+- Google Cloud Project with  Vertex AI API enabled.
+- A `credentials.json` file for accessing the Vertex AI API via a service account.
 
 ## Going further
 
 After completing the workshop, an example setup for deploying the knowledge worker to production is viewable in [gen_ai_hackathon](gen_ai_hackathon). 
 The next steps covered include separating the Gradio front-end into a separate server, and creating a FastAPI LangChain API for serving requests. 
 
-## Running the notebook for a Hack event
+## Running the notebook for a hackathon event
 
 1. Create a dedicated Google Cloud project with Vertex AI enabled.
-2. Create a service account roles: Vertex AI User (for vertex ai endpoints), Storage Object Viewer (to download demo and webarchive materials) and Storage Legacy Bucket Reader (to read the contents of buckets for dynamic selection).
+2. Create a service account roles: `Vertex AI User` (for vertex ai endpoints), `Storage Object Viewer` (to download demo and webarchive materials) and `Storage Legacy Bucket Reader` (to read the contents of buckets for dynamic selection).
 3. Distribute the JSON credentials for this service account, to allow participants to impersonate the SA and authenticate to access the Vertex AI endpoint.
-4. Post-workshop, remember to delete the key to maintain security and prevent further billing.
+4. ❗ Post-workshop, remember to delete the key to maintain security and prevent further billing.

--- a/hackathon.ipynb
+++ b/hackathon.ipynb
@@ -1,14 +1,44 @@
 {
   "cells": [
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<h1 align=\"center\"> Generative AI Hackathon</h1>\n",
+        "<table align=\"center\">\n",
+        "    <td>\n",
+        "        <a href=\"https://colab.research.google.com/github/teamdatatonic/gen-ai-hackathon/blob/main/hackathon.ipynb\">\n",
+        "            <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\">\n",
+        "            <span style=\"vertical-align: middle;\">Run in Colab</span>\n",
+        "        </a>\n",
+        "    </td>\n",
+        "    <td>\n",
+        "        <a href=\"https://github.com/teamdatatonic/gen-ai-hackathon/blob/main/hackathon.ipynb\">\n",
+        "            <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "            <span style=\"vertical-align: middle;\">View on GitHub</span>\n",
+        "        </a>\n",
+        "    </td>\n",
+        "    <td>\n",
+        "        <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/teamdatatonic/gen-ai-hackathon/main/hackathon.ipynb\">\n",
+        "            <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"> \n",
+        "            <span style=\"vertical-align: middle;\">Open in Vertex AI Workbench</span>\n",
+        "        </a>\n",
+        "    </td>\n",
+        "</table>\n",
+        "<hr>\n",
+        "\n",
+        "**➡️ Your task:** Learn about Generative AI by building your own Knowledge Worker using Python and LangChain!\n",
+        "\n",
+        "**❗ Note:** This workshop has been designed to be run in Google CoLab. Support for running the workshop locally or using VertexAI Workbench is provided, but we heavily recommend CoLab for the best experience.\n"
+      ]
+    },
+    {
       "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ScHDNga8s3Rw"
       },
       "source": [
-        "# Generative AI Hackathon\n",
-        "\n",
         "## Introduction\n",
         "\n",
         "This notebook walks you through the challenge of implementing a **Knowledge Worker** for your organisation using **Generative AI**!\n",


### PR DESCRIPTION
Add VertexAI Workbench support, to enable users to run the workshop in their own workbenches (still requires a VertexAI service account to run).