### PR TITLE
feat: add rate limiter to embeddings

### DIFF
--- a/knowledge_worker/hackathon_answers.ipynb
+++ b/knowledge_worker/hackathon_answers.ipynb
@@ -113,10 +113,10 @@
   },
   {
    "cell_type": "markdown",
-   "source": [],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": []
   },
   {
    "cell_type": "code",
@@ -126,7 +126,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --quiet \"git+https://github.com/teamdatatonic/gen-ai-hackathon.git@main#subdirectory=knowledge_worker/dt_gen_ai_hackathon_helper\""
+    "%pip install --quiet \"git+https://github.com/teamdatatonic/gen-ai-hackathon.git@main#subdirectory=knowledge_worker/dt_gen_ai_hackathon_helper\"\n"
    ]
   },
   {
@@ -149,7 +149,7 @@
     "import IPython\n",
     "\n",
     "app = IPython.Application.instance()\n",
-    "app.kernel.do_shutdown(True)"
+    "app.kernel.do_shutdown(True)\n"
    ]
   },
   {
@@ -178,7 +178,7 @@
    "outputs": [],
    "source": [
     "# @markdown Set user credentials.\n",
-    "!gcloud auth application-default login"
+    "!gcloud auth application-default login\n"
    ]
   },
   {
@@ -193,7 +193,7 @@
     "PROJECT_ID = \"dt-gen-ai-hackathon-dev\"  # @param {type:\"string\"}\n",
     "aiplatform.init(project=PROJECT_ID)\n",
     "\n",
-    "!gcloud config set project {PROJECT_ID}"
+    "!gcloud config set project {PROJECT_ID}\n"
    ]
   },
   {
@@ -296,6 +296,9 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "Go to the Preview tab and start questioning your data store. You can use the following questions as examples:\n",
     "> \n",
@@ -306,19 +309,16 @@
     "> 👩‍💻: What were Alphabet revenues in 2021? \n",
     ">\n",
     "> 👩‍💻: What is the name of the CEO of Alphabet in 2021? "
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "![Preview tab](https://github.com/teamdatatonic/gen-ai-hackathon/blob/89155c8e37cc85a716c81db25cc681756257a7fc/assets/preview_tab.png?raw=true)"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "![Preview tab](https://github.com/teamdatatonic/gen-ai-hackathon/blob/89155c8e37cc85a716c81db25cc681756257a7fc/assets/preview_tab.png?raw=true)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -360,7 +360,7 @@
     "\n",
     "retriever = GoogleCloudEnterpriseSearchRetriever(\n",
     "    project_id=PROJECT_ID, search_engine_id=data_store_id\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -392,7 +392,7 @@
     "retrieval_qa = RetrievalQA.from_chain_type(\n",
     "    llm=llm, chain_type=\"stuff\", retriever=retriever\n",
     ")\n",
-    "retrieval_qa.run(search_query)"
+    "retrieval_qa.run(search_query)\n"
    ]
   },
   {
@@ -415,7 +415,7 @@
     ")\n",
     "results = retrieval_qa({\"query\": search_query})\n",
     "df = formatter_helper.format_results(results)\n",
-    "df"
+    "df\n"
    ]
   },
   {
@@ -439,7 +439,7 @@
     "    llm=llm, chain_type=\"stuff\", retriever=retriever\n",
     ")\n",
     "\n",
-    "retrieval_qa_with_sources({\"question\": search_query}, return_only_outputs=True)"
+    "retrieval_qa_with_sources({\"question\": search_query}, return_only_outputs=True)\n"
    ]
   },
   {
@@ -476,7 +476,7 @@
     "search_query = \"What were alphabet revenues in 2021?\"\n",
     "\n",
     "result = conversational_retrieval({\"question\": search_query})\n",
-    "print(result[\"answer\"])"
+    "print(result[\"answer\"])\n"
    ]
   },
   {
@@ -487,7 +487,7 @@
    "source": [
     "new_query = \"What about costs and expenses?\"\n",
     "result = conversational_retrieval({\"question\": new_query})\n",
-    "print(result[\"answer\"])"
+    "print(result[\"answer\"])\n"
    ]
   },
   {
@@ -499,7 +499,7 @@
     "new_query = \"Is this more than in 2020?\"\n",
     "\n",
     "result = conversational_retrieval({\"question\": new_query})\n",
-    "print(result[\"answer\"])"
+    "print(result[\"answer\"])\n"
    ]
   },
   {
@@ -583,7 +583,7 @@
     "    llm=llm, chain_type=\"stuff\", retriever=retriever, return_source_documents=True\n",
     ")\n",
     "\n",
-    "print(qa.combine_documents_chain.llm_chain.prompt.template)"
+    "print(qa.combine_documents_chain.llm_chain.prompt.template)\n"
    ]
   },
   {
@@ -625,7 +625,7 @@
     "\n",
     "Question: {question}\n",
     "Helpful Answer:\n",
-    "\"\"\""
+    "\"\"\"\n"
    ]
   },
   {
@@ -642,7 +642,7 @@
     ")\n",
     "qa_chain = RetrievalQA.from_llm(\n",
     "    llm=llm, prompt=prompt_a, retriever=retriever, return_source_documents=True\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -651,7 +651,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(qa_chain.combine_documents_chain.llm_chain.prompt.template)"
+    "print(qa_chain.combine_documents_chain.llm_chain.prompt.template)\n"
    ]
   },
   {
@@ -664,7 +664,7 @@
     "\n",
     "results = qa_chain({\"query\": search_query})\n",
     "df = formatter_helper.format_results(results)\n",
-    "df"
+    "df\n"
    ]
   },
   {
@@ -686,7 +686,7 @@
     "\n",
     "results = qa_chain({\"query\": search_query})\n",
     "df = formatter_helper.format_results(results)\n",
-    "df"
+    "df\n"
    ]
   },
   {
@@ -711,7 +711,7 @@
     "\n",
     "vertex_ai_search.ingest_documents(project_id=PROJECT_ID, location=location, data_store_id=data_store_id,\n",
     "                                  gcs_uri=gcs_uri,\n",
-    "                                  data_schema=\"content\")"
+    "                                  data_schema=\"content\")\n"
    ]
   },
   {
@@ -724,7 +724,7 @@
     "\n",
     "results = qa_chain({\"query\": search_query})\n",
     "df = formatter_helper.format_results(results)\n",
-    "df"
+    "df\n"
    ]
   },
   {
@@ -773,7 +773,7 @@
     "        llm=llm, retriever=retriever,\n",
     "        return_source_documents=True\n",
     "    )\n",
-    "    return conversational_retrieval"
+    "    return conversational_retrieval\n"
    ]
   },
   {
@@ -786,7 +786,7 @@
     "\n",
     "qa_chain_ui = create_qa_vertex_ai_search_chain()\n",
     "demo = view.View(qa_chain=qa_chain_ui)\n",
-    "demo.launch_interface()"
+    "demo.launch_interface()\n"
    ]
   },
   {
@@ -858,7 +858,7 @@
    "outputs": [],
    "source": [
     "BUCKET = \"dt-gen-ai-hackathon-webarchive\"\n",
-    "LOCAL_FOLDER = \"www.datatonic.com.tar.gz\""
+    "LOCAL_FOLDER = \"www.datatonic.com.tar.gz\"\n"
    ]
   },
   {
@@ -867,7 +867,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gsutil cp gs: // {BUCKET} / {LOCAL_FOLDER}.& & tar -xzf {LOCAL_FOLDER}"
+    "!gsutil cp gs: // {BUCKET} / {LOCAL_FOLDER}.& & tar -xzf {LOCAL_FOLDER}\n"
    ]
   },
   {
@@ -913,7 +913,7 @@
     "\n",
     "    print(f\"Loaded: {len(documents)} documents from {source_dir}.\")\n",
     "\n",
-    "    return documents"
+    "    return documents\n"
    ]
   },
   {
@@ -941,7 +941,7 @@
    "source": [
     "# @title Set the name of your vectorstore { run: \"auto\", display-mode: \"form\" }\n",
     "# @markdown This variable can be left as default for this task.\n",
-    "PERSIST_DIR = \"chromadb\"  # @param {type:\"string\"}"
+    "PERSIST_DIR = \"chromadb\"  # @param {type:\"string\"}\n"
    ]
   },
   {
@@ -952,29 +952,25 @@
    },
    "outputs": [],
    "source": [
+    "import time\n",
+    "from typing import List\n",
     "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
     "from langchain.vectorstores import Chroma\n",
     "from langchain.embeddings import VertexAIEmbeddings\n",
     "\n",
-    "\n",
-    "def create_embeddings(source_dir):\n",
-    "    documents = load_documents(source_dir=source_dir)\n",
-    "\n",
-    "    # We use Google embeddings model, however other models can be substituted here\n",
-    "    embeddings = VertexAIEmbeddings(model_name='textembedding-gecko@001', max_retries=2, request_parallelism=2)\n",
-    "\n",
-    "    # Individual documents will often exceed the token limit.\n",
-    "    # By splitting documents into chunks of 1000 token\n",
-    "    # These chunks fit into the token limit alongside the user prompt\n",
-    "    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=0)\n",
-    "    texts = text_splitter.split_documents(documents)\n",
-    "\n",
-    "    vector_store = Chroma.from_documents(\n",
-    "        documents=texts, embedding=embeddings, persist_directory=PERSIST_DIR\n",
-    "    )\n",
-    "\n",
-    "    # Persist the ChromaDB locally, so we can reload the script without expensively re-embedding the database\n",
-    "    vector_store.persist()"
+    "# Utility functions for Embeddings API with rate limiting\n",
+    "def rate_limit(max_per_minute):\n",
+    "    period = 60 / max_per_minute\n",
+    "    print(\"Waiting\")\n",
+    "    while True:\n",
+    "        before = time.time()\n",
+    "        yield\n",
+    "        after = time.time()\n",
+    "        elapsed = after - before\n",
+    "        sleep_time = max(0, period - elapsed)\n",
+    "        if sleep_time > 0:\n",
+    "            print(\".\", end=\"\")\n",
+    "            time.sleep(sleep_time)\n"
    ]
   },
   {
@@ -983,12 +979,66 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Note: This will take a few minutes to run\n",
+    "class CustomVertexAIEmbeddings(VertexAIEmbeddings):\n",
+    "    requests_per_minute: int\n",
+    "    num_instances_per_batch: int\n",
     "\n",
+    "    # Overriding embed_documents method\n",
+    "    def embed_documents(self, texts: List[str]):\n",
+    "        limiter = rate_limit(self.requests_per_minute)\n",
+    "        results = []\n",
+    "        docs = list(texts)\n",
+    "\n",
+    "        while docs:\n",
+    "            # Working in batches because the API accepts maximum 5\n",
+    "            # documents per request to get embeddings\n",
+    "            head, docs = (\n",
+    "                docs[: self.num_instances_per_batch],\n",
+    "                docs[self.num_instances_per_batch :],\n",
+    "            )\n",
+    "            chunk = self.client.get_embeddings(head)\n",
+    "            results.extend(chunk)\n",
+    "            next(limiter)\n",
+    "\n",
+    "        return [r.values for r in results]\n",
+    "\n",
+    "def create_embeddings(source_dir, requests_per_minute, num_instances_per_batch):\n",
+    "    documents = load_documents(source_dir=source_dir)\n",
+    "\n",
+    "    # Use the CustomVertexAIEmbeddings class with rate limiting\n",
+    "    embeddings = CustomVertexAIEmbeddings(\n",
+    "        model_name='textembedding-gecko@001',\n",
+    "        max_retries=2,\n",
+    "        request_parallelism=2,\n",
+    "        requests_per_minute=requests_per_minute,\n",
+    "        num_instances_per_batch=num_instances_per_batch\n",
+    "    )\n",
+    "\n",
+    "    # Split documents into chunks to fit the token limit\n",
+    "    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=0)\n",
+    "    texts = text_splitter.split_documents(documents)\n",
+    "\n",
+    "    vector_store = Chroma.from_documents(\n",
+    "        documents=texts, embedding=embeddings, persist_directory=PERSIST_DIR\n",
+    "    )\n",
+    "\n",
+    "    # Persist the ChromaDB locally\n",
+    "    vector_store.persist()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: This will take a few minutes to run (about 4 minutes)\n",
     "create_embeddings(\n",
-    "    source_dir=LOCAL_FOLDER.rstrip('.tar.gz')\n",
-    ")  # creates the vector DB and saves it locally. Be patient, this may take a few minutes.\n",
-    "print(f\"Created new vectorstore in dir {PERSIST_DIR}.\")"
+    "    source_dir=LOCAL_FOLDER.rstrip('.tar.gz'),\n",
+    "    requests_per_minute=60,\n",
+    "    num_instances_per_batch=5\n",
+    ")  # creates the vector DB and saves it locally.\n",
+    "print(f\"Created new vectorstore in dir {PERSIST_DIR}.\")\n"
    ]
   },
   {
@@ -1018,7 +1068,7 @@
     "        persist_directory=persist_directory,\n",
     "    )\n",
     "\n",
-    "    return vector_store"
+    "    return vector_store\n"
    ]
   },
   {
@@ -1032,7 +1082,7 @@
     "vector_store = load_embeddings(\n",
     "    PERSIST_DIR\n",
     ")  # loads the vector DB from the local file system.\n",
-    "print(f\"Loaded {PERSIST_DIR} as vectorstore.\")"
+    "print(f\"Loaded {PERSIST_DIR} as vectorstore.\")\n"
    ]
   },
   {
@@ -1098,7 +1148,7 @@
     "        return_source_documents=True\n",
     "    )\n",
     "\n",
-    "    return chain"
+    "    return chain\n"
    ]
   },
   {
@@ -1125,7 +1175,7 @@
     ")\n",
     "\n",
     "demo = view.View(qa_chain=qa_chain)\n",
-    "demo.launch_interface()"
+    "demo.launch_interface()\n"
    ]
   },
   {
@@ -1189,7 +1239,7 @@
    "outputs": [],
    "source": [
     "# Downloading documents locally\n",
-    "!gsutil -m cp -r \"gs://dt-gen-ai-hackathon-pdf-datasets/alphabet_investor_pdfs_2004_2021\"."
+    "!gsutil -m cp -r \"gs://dt-gen-ai-hackathon-pdf-datasets/alphabet_investor_pdfs_2004_2021\".\n"
    ]
   },
   {
@@ -1223,7 +1273,7 @@
     "    # \"save\" the new vector store back to the file system\n",
     "    vector_store.persist()\n",
     "\n",
-    "    print(\"Finished adding new documents to the vectorstore.\")"
+    "    print(\"Finished adding new documents to the vectorstore.\")\n"
    ]
   },
   {
@@ -1236,7 +1286,7 @@
    "source": [
     "load_pdf_documents(\n",
     "    filepath=\"alphabet_investor_pdfs_2004_2021/2004_google_annual_report.pdf\"\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -1269,7 +1319,7 @@
     ")\n",
     "\n",
     "demo = view.View(qa_chain=qa_chain)\n",
-    "demo.launch_interface()"
+    "demo.launch_interface()\n"
    ]
   },
   {
@@ -1305,7 +1355,7 @@
    "source": [
     "# @title Set LLM temperature { run: \"auto\", display-mode: \"form\" }\n",
     "# @markdown Temperature controls the degree of creativity / randomness introduced into the LLM.\n",
-    "temperature = 0.7  # @param {type:\"slider\", min:0, max:1, step:0.01}"
+    "temperature = 0.7  # @param {type:\"slider\", min:0, max:1, step:0.01}\n"
    ]
   },
   {
@@ -1322,7 +1372,7 @@
     "Topic: {topic}\n",
     "\"\"\"\n",
     "\n",
-    "SECTION_02_PROMPT = PromptTemplate.from_template(SECTION_02_TEMPLATE)"
+    "SECTION_02_PROMPT = PromptTemplate.from_template(SECTION_02_TEMPLATE)\n"
    ]
   },
   {
@@ -1337,7 +1387,7 @@
     "\n",
     "model = VertexAI(model_name='text-bison@001', temperature=temperature)\n",
     "\n",
-    "chain = LLMChain(llm=model, prompt=SECTION_02_PROMPT)"
+    "chain = LLMChain(llm=model, prompt=SECTION_02_PROMPT)\n"
    ]
   },
   {
@@ -1358,7 +1408,7 @@
     "    # generate blog outline\n",
     "    output = chain.apply(inputs)\n",
     "\n",
-    "    return output"
+    "    return output\n"
    ]
   },
   {
@@ -1382,7 +1432,7 @@
    "source": [
     "# @title Set blog prompt / title { run: \"auto\", display-mode: \"form\" }\n",
     "# @markdown Be descriptive, as the LLM will collect semantically similar sources as inspiration.\n",
-    "BLOG_TITLE = \"How we're making our business more sustainable\"  # @param {type:\"string\"}"
+    "BLOG_TITLE = \"How we're making our business more sustainable\"  # @param {type:\"string\"}\n"
    ]
   },
   {
@@ -1402,7 +1452,7 @@
     "for i, blog in enumerate(output):\n",
     "    markdown += f\"# #{i} {BLOG_TITLE}\\n{blog['text']}\\n\\n\"\n",
     "\n",
-    "display(Markdown(markdown))"
+    "display(Markdown(markdown))\n"
    ]
   },
   {
@@ -1513,7 +1563,7 @@
    },
    "outputs": [],
    "source": [
-    "# Write your ideas/code here"
+    "# Write your ideas/code here\n"
    ]
   },
   {


### PR DESCRIPTION
Added a function to limit the number of requests per minute to 60. 
With this setup, even if all 25 users are making requests simultaneously, the total number of requests being sent to the API will stay within the 1500 calls per minute limit.